### PR TITLE
New version of actix-web & actix-net

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,22 +7,22 @@ repository = "https://github.com/jeizsm/actix-telegram"
 license = "MIT"
 
 [dependencies]
-actix = "0.7"
-actix-web = { version = "0.7.13" }
-actix-net = { version = "0.1" }
+actix = "^0.7.6"
+actix-web = { version = "^0.7.14" }
+actix-net = { version = "^0.2.2" }
 actix-telegram-derive = { path="./actix-telegram-derive", version="0.1" }
 multipart-rfc7578 = { version = "0.6", features=["actix-web"] }
 futures = "0.1"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = "^1.0.80"
+serde_derive = "^1.0.80"
+serde_json = "^1.0.33"
 tokio = "0.1"
-log = "0.4"
-env_logger = "0.5"
+log = "^0.4.6"
+env_logger = "^0.6.0"
 rustls = { version = "0.14", optional = true }
-openssl = { version = "0.10", optional = true }
-native-tls = { version = "0.2", optional = true }
-bitflags = "1.0"
+openssl = { version = "^0.10.15", optional = true }
+native-tls = { version = "^0.2.2", optional = true }
+bitflags = "^1.0.4"
 
 [features]
 default = ["tls-server", "rust-tls"]


### PR DESCRIPTION
After upgrade actix-net to 0.2, current release does not compile:
```
error[E0308]: mismatched types
   --> src/actors/telegram_server/mod.rs:150:28
    |
150 |         self.server = Some(server.start());
    |                            ^^^^^^^^^^^^^^ expected struct `actix_net::server::Server`, found struct `actix_net::server::server::Server`
    |
    = note: expected type `actix::Addr<actix_net::server::Server>`
               found type `actix::Addr<actix_net::server::server::Server>`
```

Pull request updates all dependencies to latest version. This fixes compile error and also removes duplications when latest versions are used.